### PR TITLE
Temporarily put an upper-bound to scikit-learn

### DIFF
--- a/tools/accuracy_checker/requirements-extra.in
+++ b/tools/accuracy_checker/requirements-extra.in
@@ -15,7 +15,7 @@ imagecodecs~=2021.11.20;python_version=="3.7"
 imagecodecs~=2022.2.22;python_version>="3.8"
 
 # reid
-scikit-learn>=1.2.0
+scikit-learn>=1.2.0,<=1.2.1
 
 # cpu extension usage
 py-cpuinfo>=7.0.0


### PR DESCRIPTION
due to compatibility issues in pip-conflicts check after 1.2.2 release